### PR TITLE
Add CLERC EPEE (expert-annotated ASL, native Deaf signers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following colors represent different sign languages: 🟥 CSL, 🟦 DGS, �
 - Isolated sign language recognition benchmarks:
   - 🟨 **WLASL**: 14,289, 3,916, and 2,878 video segments in the train, dev, and test splits, respectively. [[Link](https://dxli94.github.io/WLASL/)]
   - 🟨 **MSASL**: 16,054, 5,287, and 4,172 video segments in the train, dev, and test splits, respectively. [[Link](https://www.microsoft.com/en-us/research/project/ms-asl/)]
+  - 🟨 **EPEE**: 600 ASL clips from 4 native Deaf signers, with sign-level segmentation, gloss labels, and 128 keypoints per frame; includes a cross-signer recognition benchmark. [[Link](https://huggingface.co/datasets/CLERC-DATA/epee)][[Project](https://clerc.io/data)]
   - 🟥 **NMFs-CSL**: 25,608 and 6,402 video segments in the train and test splits, respectively. [[Link](https://ustc-slr.github.io/datasets/2020_nmfs_csl/)]
   - 🟥 **SLR500**: 90,000 and 35,000 video segments in the train and test splits, respectively. [[Link](http://home.ustc.edu.cn/~hagjie/)]
   - 🟪 **Slovo**: 15,300 and 5,100 video segments in the train and test splits, respectively. [[Link](https://github.com/hukenovs/slovo)]


### PR DESCRIPTION
Adds EPEE, an open, DOI-citable ASL benchmark subset built with native Deaf signers: 600 clips from 4 signers with sign-level segmentation, gloss labels, and 128 keypoints per frame, plus a cross-signer recognition benchmark.

Dataset: https://huggingface.co/datasets/CLERC-DATA/epee

DOI: https://doi.org/10.5281/zenodo.20268565

Placed under Isolated sign language recognition benchmarks (ASL). Thanks for maintaining this list!